### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "matt/wp-installer",
     "description": "WP Installer CLI Command",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/mattgrshaw/wp-installer",
     "support": {
         "issues": "https://github.com/mattgrshaw/wp-installer"


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
